### PR TITLE
Refactor encode_to_json/1 function

### DIFF
--- a/lib/omise/utils.ex
+++ b/lib/omise/utils.ex
@@ -4,20 +4,18 @@ defmodule Omise.Utils do
   @spec encode_to_json(Keyword.t) :: iodata | no_return
   def encode_to_json(body_params) when is_list(body_params) do
     body_params
-    |> normalize_req_body_params()
+    |> normalize_params()
     |> Poison.encode!
   end
 
-  defp normalize_req_body_params(params) when is_list(params) do
+  defp normalize_params(params) when is_list(params) do
     params
     |> Enum.map(&transform_value/1)
     |> Enum.into(%{})
   end
 
-  defp transform_value({key, value}) when is_list(value) do
-    {key, Enum.into(normalize_req_body_params(value), %{})}
-  end
-  defp transform_value(kv) do
-    kv
-  end
+  defp transform_value({key, [head | _] = value}) when is_tuple(head),
+    do: {key, Enum.into(normalize_params(value), %{})}
+  defp transform_value(kv),
+    do: kv
 end

--- a/test/omise/utils_test.exs
+++ b/test/omise/utils_test.exs
@@ -21,6 +21,16 @@ defmodule Omise.UtilsTest do
       },
 
       %{
+        input:  [id: 1, name: "elixir", codes: [1, 2, 3]],
+        output: "{\"name\":\"elixir\",\"id\":1,\"codes\":[1,2,3]}"
+      },
+
+      %{
+        input:  [id: 1, name: "elixir", codes: []],
+        output: "{\"name\":\"elixir\",\"id\":1,\"codes\":[]}"
+      },
+
+      %{
         input:  [id: 1, bank_account: [brand: "bbl", number: "9999999999"]],
         output: "{\"id\":1,\"bank_account\":{\"number\":\"9999999999\",\"brand\":\"bbl\"}}"
       }


### PR DESCRIPTION
To make it support both `list` and `keyword list` types.