### PR TITLE
Add functions for transfer schedules

### DIFF
--- a/lib/omise/recipient.ex
+++ b/lib/omise/recipient.ex
@@ -190,4 +190,26 @@ defmodule Omise.Recipient do
   def search(params \\ [], opts \\ []) do
     Omise.Search.execute("recipient", params, opts)
   end
+
+  @doc ~S"""
+  List all transfer schedules for a given recipient.
+
+  Returns `{:ok, schedules}` if the request is successful, `{:error, error}` otherwise.
+
+  ## Query Parameters:
+    * `offset` - (optional, default: 0) The offset of the first record returned.
+    * `limit` - (optional, default: 20, maximum: 100) The maximum amount of records returned.
+    * `from` - (optional, default: 1970-01-01T00:00:00Z, format: ISO 8601) The UTC date and time limiting the beginning of returned records.
+    * `to` - (optional, default: current UTC Datetime, format: ISO 8601) The UTC date and time limiting the end of returned records.
+
+  ## Examples
+
+      Omise.Recipient.list_schedules("recp_test_556jkf7u174ptxuytac")
+
+  """
+  @spec list_schedules(String.t, Keyword.t, Keyword.t) :: {:ok, Omise.List.t} | {:error, Omise.Error.t}
+  def list_schedules(id, params \\ [], opts \\ []) do
+    opts = Keyword.merge(opts, as: %Omise.List{data: [%Omise.Schedule{}]})
+    get("#{@endpoint}/#{id}/schedules", params, opts)
+  end
 end

--- a/lib/omise/schedule.ex
+++ b/lib/omise/schedule.ex
@@ -117,7 +117,8 @@ defmodule Omise.Schedule do
     * `start_date` - (optional) When the schedule should start, in ISO 8601 format (YYYY-MM-DD). Defaults to today.
     * `end_date` - When the schedule should end, in ISO 8601 format (YYYY-MM-DD).
     * `capture` - (optional) Whether or not you want the charge to be captured right away, when not specified it is set to true.
-    * `charge` - A charge hash.
+    * `charge` - A charge map. (for charge schedule)
+    * `transfer` - A transfer map. (for transfer schedule)
 
   ## Examples
 
@@ -182,6 +183,32 @@ defmodule Omise.Schedule do
         ]
       )
 
+      # Transfer a fixed amount every 2 days
+      Omise.Schedule.create(
+        every: 2,
+        period: "day",
+        start_date: "2017-07-8",
+        end_date: "2017-07-31",
+        transfer: [
+          recipient: "recp_test_55j2an6c8fd07xbccd3",
+          amount: 100_00_00,
+        ]
+      )
+
+      # Transfer a percentage of the balance every Monday and Friday
+      Omise.Schedule.create(
+        every: 1,
+        period: "week",
+        on: [
+          weekdays: ["monday", "friday"],
+        ],
+        start_date: "2017-07-8",
+        end_date: "2017-07-31",
+        transfer: [
+          recipient: "recp_test_556jkf7u174ptxuytac",
+          percentage_of_balance: 75,
+        ]
+      )
   """
   @spec create(Keyword.t, Keyword.t) :: {:ok, t} | {:error, Omise.Error.t}
   def create(params, opts \\ []) do

--- a/lib/omise/transfer.ex
+++ b/lib/omise/transfer.ex
@@ -147,4 +147,26 @@ defmodule Omise.Transfer do
     opts = Keyword.merge(opts, as: %__MODULE__{})
     delete("#{@endpoint}/#{id}", opts)
   end
+
+  @doc ~S"""
+  List all transfer schedules.
+
+  Returns `{:ok, schedules}` if the request is successful, `{:error, error}` otherwise.
+
+  ## Query Parameters:
+    * `offset` - (optional, default: 0) The offset of the first record returned.
+    * `limit` - (optional, default: 20, maximum: 100) The maximum amount of records returned.
+    * `from` - (optional, default: 1970-01-01T00:00:00Z, format: ISO 8601) The UTC date and time limiting the beginning of returned records.
+    * `to` - (optional, default: current UTC Datetime, format: ISO 8601) The UTC date and time limiting the end of returned records.
+
+  ## Examples
+
+      Omise.Transfer.list_schedules
+
+  """
+  @spec list_schedules(Keyword.t, Keyword.t) :: {:ok, Omise.List.t} | {:error, Omise.Error.t}
+  def list_schedules(params \\ [], opts \\ []) do
+    opts = Keyword.merge(opts, as: %Omise.List{data: [%Omise.Schedule{}]})
+    get("#{@endpoint}/schedules", params, opts)
+  end
 end


### PR DESCRIPTION
Add function `list_schedules/3` and `list_schedules/2` for `Recipient` and `Transfer` modules respectively.